### PR TITLE
Normalize movement vector to fix strafe speed

### DIFF
--- a/client/src/main/java/com/ultreon/craft/client/input/PlayerInput.java
+++ b/client/src/main/java/com/ultreon/craft/client/input/PlayerInput.java
@@ -68,7 +68,7 @@ public class PlayerInput {
         else if (this.moveY != 0 && player.xRot < player.xHeadRot)
             player.xRot = Math.min(player.xRot + (45 / (player.xHeadRot - player.xRot)), player.xHeadRot);
 
-        this.tmp.set(this.moveX, 0, moveY).nor().scl(-speed, 0, speed).rotate(player.xHeadRot, 0, 1, 0);
+        this.tmp.set(-this.moveX, 0, moveY).nor().scl(speed).rotate(player.xHeadRot, 0, 1, 0);
         this.vel.set(this.tmp);
     }
 

--- a/client/src/main/java/com/ultreon/craft/client/input/PlayerInput.java
+++ b/client/src/main/java/com/ultreon/craft/client/input/PlayerInput.java
@@ -68,7 +68,7 @@ public class PlayerInput {
         else if (this.moveY != 0 && player.xRot < player.xHeadRot)
             player.xRot = Math.min(player.xRot + (45 / (player.xHeadRot - player.xRot)), player.xHeadRot);
 
-        this.tmp.set(-speed * this.moveX, 0, speed * this.moveY).rotate(player.xHeadRot, 0, 1, 0);
+        this.tmp.set(this.moveX, 0, moveY).nor().scl(-speed, 0, speed).rotate(player.xHeadRot, 0, 1, 0);
         this.vel.set(this.tmp);
     }
 


### PR DESCRIPTION
The velocity vector when strafing would have magnitude = speed * sqrt(2) instead of just speed, because it was the sum of the 2 components wasn't normalized. I have modified the `tmp` vector calculation as to normalize it using `nor()`, then scale it by the correct factors with a library method.